### PR TITLE
Fixed problem with aggregate logger throwing exception when used with…

### DIFF
--- a/src/Prism.Plugin.Logging.Abstractions/AggregateLogger.cs
+++ b/src/Prism.Plugin.Logging.Abstractions/AggregateLogger.cs
@@ -49,15 +49,15 @@ namespace Prism.Logging
         }
 
         void ILogger.Log(string message, IDictionary<string, string> properties) =>
-            InvokeOnLogger(l => l.Log(message, properties));
+            InvokeOnLogger(l => l.Log(message, new Dictionary<string, string>(properties)));
 
         void ILoggerFacade.Log(string message, Category category, Priority priority) =>
             InvokeOnLogger(l => l.Log(message, category, priority));
 
         void IAnalyticsService.TrackEvent(string name, IDictionary<string, string> properties) =>
-            InvokeOnLogger(l => l.TrackEvent(name, properties));
+            InvokeOnLogger(l => l.TrackEvent(name, new Dictionary<string, string>(properties)));
 
         void ICrashesService.Report(Exception ex, IDictionary<string, string> properties) =>
-            InvokeOnLogger(l => l.Report(ex, properties));
+            InvokeOnLogger(l => l.Report(ex, new Dictionary<string, string>(properties)));
     }
 }


### PR DESCRIPTION
… some combinations of multiple loggers. For example, if AppCenter and Loggly loggers were used and an exception tried to be published, the first logger would populate the "StackTrace" key in the dictionary and the second one would try to add it again. The dictionary should be reset to the original version for each logger.